### PR TITLE
Add NetworkPolicy to allow same-namespace ingress

### DIFF
--- a/app-chart/templates/network-policy.yaml
+++ b/app-chart/templates/network-policy.yaml
@@ -57,3 +57,18 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: traefik
+
+---
+# 4. THE NEIGHBORS: Allow All Traffic Within the Namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}


### PR DESCRIPTION
Adds an `allow-same-namespace` policy so pods within the release namespace can communicate freely via ingress.