### PR TITLE
refactor: unify main and sidecar container specs with a shared helper

### DIFF
--- a/app-chart/templates/deployment.yaml
+++ b/app-chart/templates/deployment.yaml
@@ -22,32 +22,10 @@ spec:
         app: {{ $appName }}
     spec:
       containers:
-        - image: "{{ $app.image.repository }}:{{ $app.image.tag | default "latest" }}"
-          name: {{ $appName }}
-{{- with $app.args }}
-          args:
-{{- toYaml . | nindent 12 }}
-{{- end }}
-      {{- with (include "app-chart.deployment.containerPorts" (dict "ports" $app.ports "appName" $appName)) }}{{ . | nindent 10 }}{{- end }}
-      {{- with (include "app-chart.deployment.envFrom" (dict "envFrom" $app.envFrom)) }}{{ . | nindent 10 }}{{- end }}
-      {{- with (include "app-chart.deployment.env" (dict "env" $app.env "context" $ "appName" $appName)) }}{{ . | nindent 10 }}{{- end }}
-      {{- with (include "app-chart.deployment.livenessProbe" (dict "livenessProbe" $app.livenessProbe "appName" $appName)) }}{{ . | nindent 10 }}{{- end }}
-      {{- with (include "app-chart.deployment.readinessProbe" (dict "readinessProbe" $app.readinessProbe "appName" $appName)) }}{{ . | nindent 10 }}{{- end }}
-      {{- with (include "app-chart.deployment.volumeMounts" (dict "volumes" $app.volumes "configMounts" $app.configMounts "configMaps" $.Values.configMaps "appName" $appName)) }}{{ . | nindent 10 }}{{- end }}
+{{- include "app-chart.deployment.container" (dict "container" $app "name" $appName "appName" $appName "context" $) | nindent 8 }}
 {{- if $app.sidecars }}
 {{- range $sidecar := $app.sidecars }}
-        - name: {{ $sidecar.name }}
-          image: "{{ $sidecar.image.repository }}:{{ $sidecar.image.tag | default "latest" }}"
-          {{- with $sidecar.args }}
-          args:
-{{ toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with (include "app-chart.deployment.containerPorts" (dict "ports" $sidecar.ports "appName" $appName)) }}{{ . | nindent 10 }}{{- end }}
-          {{- with (include "app-chart.deployment.envFrom" (dict "envFrom" $sidecar.envFrom)) }}{{ . | nindent 10 }}{{- end }}
-          {{- with (include "app-chart.deployment.env" (dict "env" $sidecar.env "context" $ "appName" $appName)) }}{{ . | nindent 10 }}{{- end }}
-          {{- with (include "app-chart.deployment.livenessProbe" (dict "livenessProbe" $sidecar.livenessProbe "appName" $appName)) }}{{ . | nindent 10 }}{{- end }}
-          {{- with (include "app-chart.deployment.readinessProbe" (dict "readinessProbe" $sidecar.readinessProbe "appName" $appName)) }}{{ . | nindent 10 }}{{- end }}
-          {{- with (include "app-chart.deployment.volumeMounts" (dict "volumes" $sidecar.volumeMounts)) }}{{ . | nindent 10 }}{{- end }}
+{{- include "app-chart.deployment.container" (dict "container" $sidecar "name" $sidecar.name "appName" $appName "context" $) | nindent 8 }}
 {{- end }}
 {{- end }}
     {{- with (include "app-chart.deployment.volumes" (dict "volumes" $app.volumes "configMounts" $app.configMounts "configMaps" $.Values.configMaps "appName" $appName)) }}{{ . | nindent 6 }}{{- end }}

--- a/app-chart/templates/helpers/_deployment.tpl
+++ b/app-chart/templates/helpers/_deployment.tpl
@@ -1,4 +1,50 @@
+{{/* Renders a container spec (main or sidecar) */}}
+{{- define "app-chart.deployment.container" -}}
+{{- $container := .container -}}
+{{- $context := .context -}}
+{{- $appName := .appName -}}
+{{- $name := .name -}}
+- name: {{ $name }}
+  image: "{{ $container.image.repository }}:{{ $container.image.tag | default "latest" }}"
+  {{- with $container.image.pullPolicy }}
+  imagePullPolicy: {{ . }}
+  {{- end }}
+  {{- with $container.command }}
+  command:
+{{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $container.args }}
+  args:
+{{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $container.workingDir }}
+  workingDir: {{ . }}
+  {{- end }}
+  {{- with $container.securityContext }}
+  securityContext:
+{{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with (include "app-chart.deployment.containerPorts" (dict "ports" $container.ports "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
+  {{- with (include "app-chart.deployment.envFrom" (dict "envFrom" $container.envFrom)) }}{{ . | nindent 2 }}{{- end }}
+  {{- with (include "app-chart.deployment.env" (dict "env" $container.env "context" $context "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
+  {{- with (include "app-chart.deployment.resources" (dict "resources" $container.resources)) }}{{ . | nindent 2 }}{{- end }}
+  {{- with (include "app-chart.deployment.livenessProbe" (dict "livenessProbe" $container.livenessProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
+  {{- with (include "app-chart.deployment.readinessProbe" (dict "readinessProbe" $container.readinessProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
+  {{- /* Unify volume mounts: main container uses .volumes, sidecars use .volumeMounts */ -}}
+  {{- $mounts := $container.volumeMounts | default $container.volumes -}}
+  {{- with (include "app-chart.deployment.volumeMounts" (dict "volumes" $mounts "configMounts" $container.configMounts "configMaps" $context.Values.configMaps "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
+{{- end }}
+
+{{/* Renders container resources */}}
+{{- define "app-chart.deployment.resources" -}}
+{{- if .resources -}}
+resources:
+{{- toYaml .resources | nindent 2 -}}
+{{- end -}}
+{{- end }}
+
 {{/* Renders container ports for a single app */}}
+
 {{- define "app-chart.deployment.containerPorts" -}}
 {{- $ports := .ports -}}
 {{- $appName := .appName -}}

--- a/app-chart/values.schema.json
+++ b/app-chart/values.schema.json
@@ -156,7 +156,7 @@
       "type": "object",
       "properties": {
         "name": { "type": "string" },
-        "image": { "type": "string" },
+        "image": { "$ref": "#/definitions/image" },
         "args": {
           "type": "array",
           "items": { "type": "string" }


### PR DESCRIPTION
- Create app-chart.deployment.container helper to deduplicate container rendering.
- Add support for command, workingDir, securityContext, resources, and imagePullPolicy.
- Unify volume mount handling for both main containers and sidecars.
- Update values.schema.json to reflect correct sidecar image structure.