### PR TITLE
feat: add hostPath support for PVCs with automatic PV generation

### DIFF
--- a/app-chart/README.md
+++ b/app-chart/README.md
@@ -258,16 +258,19 @@ Copy the example block, rename the key (`whoami` → new service), and adjust po
 
 ### `persistentVolumeClaims.<name>` objects
 
-Every entry under `persistentVolumeClaims` renders a PVC from `templates/pvc.yaml`. Add a matching `volumes[].persistentVolumeClaim.claimName` inside the consuming app to mount it.
+Every entry under `persistentVolumeClaims` renders a PVC from `templates/pvc.yaml`. If `hostPath` is supplied, it also renders a matching `PersistentVolume` and binds them automatically. Add a matching `volumes[].persistentVolumeClaim.claimName` inside the consuming app to mount it.
 
-| Key                | Type   | Description                                                                                                | Default      |
-| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------- | ------------ |
-| `storageClassName` | string | Required. Class the PVC should bind to.                                                                    | **required** |
-| `storage`          | string | Required. Capacity request (for example `10Gi`).                                                           | **required** |
-| `backup.enabled`   | bool   | When `true`, also renders `templates/pvc-backup.yaml`, which provisions Restic CronJobs + Secret per PVC.  | `false`      |
-| `backup.schedule`  | string | Optional Cron expression for the snapshot job. Falls back to `defaults.backup.schedule`.                   | `*/30 * * * *` |
-| `backup.forgetSchedule` | string | Optional Cron expression for the retention job. Falls back to `defaults.backup.forgetSchedule`.       | `@daily`     |
-| `backup.pruningPolicy` | object | Optional overrides to the Retention policy used by the forget job.                                      | see values   |
+| Key                | Type   | Description                                                                                                                                      | Default         |
+| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------- |
+| `storage`          | string | Required. Capacity request (for example `10Gi`).                                                                                                 | **required**    |
+| `storageClassName` | string | Optional. Class the PVC should bind to. Automatically derived if `hostPath` is used.                                                             | unset           |
+| `hostPath`         | string | Optional. Local path on the host to mount. When set, an associated `PersistentVolume` is created automatically.                                  | unset           |
+| `accessMode`       | string | Optional. Access mode for the PV and PVC.                                                                                                        | `ReadWriteOnce` |
+| `reclaimPolicy`    | string | Optional. Reclaim policy for the automatically created PV (only applies when `hostPath` is set).                                                 | `Retain`        |
+| `backup.enabled`   | bool   | When `true`, also renders `templates/pvc-backup.yaml`, which provisions Restic CronJobs + Secret per PVC.                                         | `false`         |
+| `backup.schedule`  | string | Optional Cron expression for the snapshot job. Falls back to `defaults.backup.schedule`.                                                         | `*/30 * * * *`  |
+| `backup.forgetSchedule` | string | Optional Cron expression for the retention job. Falls back to `defaults.backup.forgetSchedule`.                                              | `@daily`        |
+| `backup.pruningPolicy` | object | Optional overrides to the Retention policy used by the forget job.                                                                             | see values      |
 
 When backups are enabled:
 

--- a/app-chart/values.schema.json
+++ b/app-chart/values.schema.json
@@ -460,6 +460,20 @@
       "properties": {
         "storageClassName": { "type": "string" },
         "storage": { "type": "string" },
+        "hostPath": {
+          "type": "string",
+          "description": "Optional local path on the host to mount as a PersistentVolume."
+        },
+        "accessMode": {
+          "type": "string",
+          "description": "Access mode for the PV and PVC. Defaults to ReadWriteOnce.",
+          "default": "ReadWriteOnce"
+        },
+        "reclaimPolicy": {
+          "type": "string",
+          "description": "Reclaim policy for the PV. Defaults to Retain.",
+          "default": "Retain"
+        },
         "backup": { "$ref": "#/definitions/backupPolicy" },
         "restore": {
           "type": "object",
@@ -473,7 +487,7 @@
           "additionalProperties": false
         }
       },
-      "required": ["storageClassName", "storage"],
+      "required": ["storage"],
       "additionalProperties": false
     },
     "cronJobContainer": {

--- a/library-app-chart/templates/helpers/_pvc.tpl
+++ b/library-app-chart/templates/helpers/_pvc.tpl
@@ -3,6 +3,25 @@
 {{- $name := required "pvc.claim requires a pvc name" .name -}}
 {{- $pvc := required (printf "persistentVolumeClaims.%s is required" $name) .pvc -}}
 {{- $root := required "pvc.claim requires the root context" .root -}}
+
+{{- if $pvc.hostPath -}}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ $name }}-pv
+  labels:
+    volume-name: {{ $name }}
+spec:
+  storageClassName: {{ $pvc.storageClassName | default (printf "%s-sc" $name) }}
+  capacity:
+    storage: {{ $pvc.storage }}
+  accessModes:
+    - {{ $pvc.accessMode | default "ReadWriteOnce" }}
+  persistentVolumeReclaimPolicy: {{ $pvc.reclaimPolicy | default "Retain" }}
+  hostPath:
+    path: {{ $pvc.hostPath | quote }}
+{{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -10,10 +29,19 @@ metadata:
   name: {{ $name }}
   namespace: {{ $root.Release.Namespace }}
 spec:
+  {{- if $pvc.hostPath }}
+  storageClassName: {{ $pvc.storageClassName | default (printf "%s-sc" $name) }}
+  {{- else }}
   storageClassName: {{ $pvc.storageClassName }}
+  {{- end }}
   accessModes:
-    - ReadWriteOnce
+    - {{ $pvc.accessMode | default "ReadWriteOnce" }}
   resources:
     requests:
       storage: {{ $pvc.storage }}
+  {{- if $pvc.hostPath }}
+  selector:
+    matchLabels:
+      volume-name: {{ $name }}
+  {{- end }}
 {{- end -}}


### PR DESCRIPTION
Allows defining hostPath directly in persistentVolumeClaims. When set, the chart automatically renders a matching PersistentVolume and binds it to the PVC using a selector and a matching storageClassName. Defaults reclaimPolicy to Retain to prevent accidental data loss on Mac/Local environments.