### PR TITLE
feat(app-chart): add support for Kubernetes native sidecars

### DIFF
--- a/.github/workflows/build-helm-chart.yml
+++ b/.github/workflows/build-helm-chart.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
-          version: v3.12.0
+          version: v3.14.2
 
       - name: Show helm version
         run: helm version --short

--- a/app-chart/Chart.yaml
+++ b/app-chart/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: app-chart
 description: A Helm Chart for generating Kubernetes resources for app deployment
 type: application
-version: 2.0.1
+version: 2.1.0
+kubeVersion: ">= 1.29.0"
 
 maintainers:
   - name: komailo

--- a/app-chart/templates/deployment.yaml
+++ b/app-chart/templates/deployment.yaml
@@ -21,6 +21,12 @@ spec:
       labels:
         app: {{ $appName }}
     spec:
+      {{- if $app.initContainers }}
+      initContainers:
+{{- range $init := $app.initContainers }}
+{{- include "app-chart.deployment.container" (dict "container" $init "name" $init.name "appName" $appName "context" $) | nindent 8 }}
+{{- end }}
+      {{- end }}
       containers:
 {{- include "app-chart.deployment.container" (dict "container" $app "name" $appName "appName" $appName "context" $) | nindent 8 }}
 {{- if $app.sidecars }}

--- a/app-chart/templates/helpers/_deployment.tpl
+++ b/app-chart/templates/helpers/_deployment.tpl
@@ -24,10 +24,14 @@
   securityContext:
 {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with $container.restartPolicy }}
+  restartPolicy: {{ . }}
+  {{- end }}
   {{- with (include "app-chart.deployment.containerPorts" (dict "ports" $container.ports "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
   {{- with (include "app-chart.deployment.envFrom" (dict "envFrom" $container.envFrom)) }}{{ . | nindent 2 }}{{- end }}
   {{- with (include "app-chart.deployment.env" (dict "env" $container.env "context" $context "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
   {{- with (include "app-chart.deployment.resources" (dict "resources" $container.resources)) }}{{ . | nindent 2 }}{{- end }}
+  {{- with (include "app-chart.deployment.startupProbe" (dict "startupProbe" $container.startupProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
   {{- with (include "app-chart.deployment.livenessProbe" (dict "livenessProbe" $container.livenessProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
   {{- with (include "app-chart.deployment.readinessProbe" (dict "readinessProbe" $container.readinessProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
   {{- /* Unify volume mounts: main container uses .volumes, sidecars use .volumeMounts */ -}}
@@ -88,6 +92,66 @@ env:
     {{- fail (printf "apps.%s.env[%d] requires either value or valueFrom" $appName $idx) }}
     {{- end }}
 {{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Renders optional startupProbe for a container */}}
+{{- define "app-chart.deployment.startupProbe" -}}
+{{- $probe := .startupProbe -}}
+{{- $appName := .appName -}}
+{{- if $probe -}}
+  {{- $enabled := true -}}
+  {{- if hasKey $probe "enabled" -}}
+    {{- $enabled = $probe.enabled -}}
+  {{- end -}}
+  {{- if $enabled -}}
+startupProbe:
+  {{- $probeType := default "command" $probe.type }}
+  {{- if eq $probeType "command" }}
+  exec:
+    command:
+    {{- $command := required (printf "apps.%s.startupProbe.command is required when type=command" $appName) $probe.command }}
+    {{- range $cmd := $command }}
+      - {{ $cmd | quote }}
+    {{- end }}
+  {{- else if eq $probeType "http" }}
+  httpGet:
+    {{- $port := required (printf "apps.%s.startupProbe.port is required when type=http" $appName) $probe.port }}
+    {{- $path := default "/" $probe.path }}
+    path: {{ $path | quote }}
+    port: {{ $port }}
+    {{- with $probe.host }}
+    host: {{ . | quote }}
+    {{- end }}
+    {{- with $probe.scheme }}
+    scheme: {{ . | quote }}
+    {{- end }}
+    {{- with $probe.httpHeaders }}
+    httpHeaders:
+    {{- range $idx, $header := . }}
+      - name: {{ required (printf "apps.%s.startupProbe.httpHeaders[%d].name is required" $appName $idx) $header.name | quote }}
+        value: {{ required (printf "apps.%s.startupProbe.httpHeaders[%d].value is required" $appName $idx) $header.value | quote }}
+    {{- end }}
+    {{- end }}
+  {{- else }}
+  {{- fail (printf "apps.%s.startupProbe.type %s is not supported" $appName $probeType) }}
+  {{- end }}
+  {{- with $probe.initialDelaySeconds }}
+  initialDelaySeconds: {{ . }}
+  {{- end }}
+  {{- with $probe.periodSeconds }}
+  periodSeconds: {{ . }}
+  {{- end }}
+  {{- with $probe.timeoutSeconds }}
+  timeoutSeconds: {{ . }}
+  {{- end }}
+  {{- with $probe.successThreshold }}
+  successThreshold: {{ . }}
+  {{- end }}
+  {{- with $probe.failureThreshold }}
+  failureThreshold: {{ . }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}
 

--- a/app-chart/values.schema.json
+++ b/app-chart/values.schema.json
@@ -176,6 +176,12 @@
         },
         "resources": { "type": "object" },
         "securityContext": { "type": "object" },
+        "restartPolicy": {
+          "type": "string",
+          "enum": ["Always"],
+          "description": "Restart policy for the container. Set to 'Always' for native sidecars in initContainers."
+        },
+        "startupProbe": { "$ref": "#/definitions/probe" },
         "livenessProbe": { "$ref": "#/definitions/probe" },
         "readinessProbe": { "$ref": "#/definitions/probe" },
         "ports": {
@@ -389,6 +395,7 @@
           "items": { "$ref": "#/definitions/configMapMountRef" },
           "default": []
         },
+        "startupProbe": { "$ref": "#/definitions/probe" },
         "livenessProbe": { "$ref": "#/definitions/probe" },
         "readinessProbe": { "$ref": "#/definitions/probe" },
         "service": { "$ref": "#/definitions/servicePort" },
@@ -400,6 +407,11 @@
         "volumes": {
           "type": "array",
           "items": { "$ref": "#/definitions/volumeSpec" },
+          "default": []
+        },
+        "initContainers": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/sidecarSpec" },
           "default": []
         },
         "sidecars": {


### PR DESCRIPTION
- Implement initContainers support in deployment templates.
- Add support for startupProbe in shared container helpers.
- Enable restartPolicy rendering for native sidecars (restartPolicy: Always).
- Update JSON schema to include new properties (initContainers, startupProbe, restartPolicy).
- Bump chart version to 2.1.0 and set kubeVersion to >= 1.29.0.