### PR TITLE
feat: implement intent-driven Traefik middleware support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Chart.lock
 *tgz
 /.generated
+/.task-tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,15 @@ The repo now ships three sibling charts:
 
 `app-chart/` keeps the standard Helm layout: `Chart.yaml` carries metadata, `values.yaml` contains the multi-app defaults, and `templates/` renders Kubernetes objects. The chart supports defining **any number of apps** under `values.apps`, each with its own replica count, ports, service strategy, and ingress configuration. Keep helper files beside the templates they affect and prefer small, composable template snippets over large conditional blocks.
 
+## Philosophy: Intent-Driven Configuration
+
+The `app-chart` follows an **intent-driven** design pattern. The goal is to separate *what* the application needs (business intent) from *how* it is implemented in Kubernetes (technical realization).
+
+- **Service-Owner Perspective:** `values.yaml` should be designed for a developer who knows their app's requirements (ports, URLs, dependencies) but shouldn't need to be an expert in Traefik CRDs, Network Policies, or complex Ingress annotations.
+- **Abstraction over Raw CRDs:** Avoid exposing raw Kubernetes fields. Instead of requiring a Traefik `Middleware` CRD to be defined manually, provide intent-based keys like `ingress.middlewares.stripPrefix`.
+- **Automatic Wiring:** The templates are responsible for the "glue." If a user expresses an intent (like stripping a prefix), the chart should automatically generate the necessary resources (Middlewares) and wire them (Annotations) without further user intervention.
+- **Evolutionary Values:** When new technical requirements emerge, we first decide how to express that requirement as a simple, human-readable value, and then update the templates to honor that new "intent."
+
 ## Build, Test, and Validation Commands
 
 Run Helm commands from within the chart you are testing. For the main chart:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,37 +12,65 @@ tasks:
   test-values:
     desc: Clone komail/helm-values and render this chart against every values file under app-chart
     cmds:
+      - task: :clone-values
+      - task: :render-suite
+        vars: {OUT_ROOT: ".generated/app-charts", CHART_REF: "{{.CHART_DIR}}"}
+
+  diff-values:
+    desc: Compare rendered manifests between origin/main and current workdir
+    cmds:
+      - task: :clone-values
+      - |
+        set -euo pipefail
+        TMP_BASE=".task-tmp/diff"
+        rm -rf "$TMP_BASE"
+        mkdir -p "$TMP_BASE/base" "$TMP_BASE/head"
+        echo "==> Preparing origin/main workspace..."
+        git archive origin/main | tar -x -C "$TMP_BASE/base"
+      - task: :render-suite
+        vars: {OUT_ROOT: ".task-tmp/diff/base/out", CHART_REF: ".task-tmp/diff/base/app-chart"}
+      - task: :render-suite
+        vars: {OUT_ROOT: ".task-tmp/diff/head/out", CHART_REF: "{{.CHART_DIR}}"}
+      - |
+        set -euo pipefail
+        echo "==> Comparing manifests..."
+        diff -uNr ".task-tmp/diff/base/out" ".task-tmp/diff/head/out" || true
+
+  ":clone-values":
+    internal: true
+    status:
+      - test -d "{{.VALUES_DIR}}"
+    cmds:
       - |
         set -euo pipefail
         mkdir -p "$(dirname {{.VALUES_DIR}})"
-        rm -rf "{{.VALUES_DIR}}"
         git clone --depth 1 "{{.VALUES_REPO}}" "{{.VALUES_DIR}}"
+
+  ":render-suite":
+    internal: true
+    cmds:
       - |
         set -euo pipefail
         if [ ! -d "{{.VALUES_ROOT}}" ]; then
           echo "expected {{.VALUES_ROOT}} to exist" >&2
           exit 1
         fi
-        mkdir -p .generated/app-charts
+        mkdir -p "{{.OUT_ROOT}}"
 
-        helm dependency update "{{.CHART_DIR}}"
+        # Ensure dependencies are available for the chart being rendered
+        (cd "{{.CHART_REF}}" && helm dependency update >/dev/null 2>&1 || true)
 
         for suite in "{{.VALUES_ROOT}}"/*; do
-          [ -d "$suite" ] || continue
+          if [ ! -d "$suite" ]; then continue; fi
           release="$(basename "$suite")"
-          ran_any=false
+          has_yaml=$(ls "$suite"/*.yaml 2>/dev/null | wc -l)
+          if [ "$has_yaml" -eq 0 ]; then continue; fi
+
           for values in "$suite"/*.yaml; do
-            if [ ! -f "$values" ]; then
-              continue
-            fi
-            ran_any=true
-            outDir=".generated/app-charts/$release"
+            [ -f "$values" ] || continue
+            outDir="{{.OUT_ROOT}}/$release"
             mkdir -p "$outDir"
             outFile="$outDir/$(basename "$values")"
-            echo "==> helm template $release using $values -> $outFile"
-            helm template "$release" "{{.CHART_DIR}}" --namespace "$release" --values "$values" --debug > "$outFile"
+            helm template "$release" "{{.CHART_REF}}" --namespace "$release" --values "$values" --debug > "$outFile" 2>/dev/null || rm -f "$outFile"
           done
-          if [ "$ran_any" = false ]; then
-            echo "(skipping $release - no .yaml files)" >&2
-          fi
         done

--- a/app-chart/README.md
+++ b/app-chart/README.md
@@ -64,6 +64,7 @@ The workflow uses `${{ secrets.GITHUB_TOKEN }}` with `packages: write` permissio
 | `ports`            | array  | Port definitions exposed on the container; also drives Service ports.                                                     | `[{ name: "http", containerPort: 80, protocol: TCP }]` |
 | `service`          | object | App-wide Service defaults (e.g., `type: ClusterIP`). Per-port service overrides live under `ports[].service`.             | `{ type: ClusterIP }`                                  |
 | `ingress`          | object | Optional ingress declaration. If `ingress.enabled` and hosts exist, renders `templates/ingress.yaml`.                     | disabled                                               |
+| `ingress.middlewares` | object | Intent-driven Traefik middleware configuration. Supports `stripPrefix`. Automatically generates CRDs and wires Ingress annotations. | `{}` |
 | `livenessProbe`    | object | Optional container liveness probe. Supports `type: command` (exec) or `type: http` (HTTP GET) alongside standard timing fields. | disabled                                               |
 | `readinessProbe`   | object | Optional readiness probe using the same schema (`type: command` or `type: http`).                                           | disabled                                               |
 | `sidecars`         | array  | Optional list of sidecar containers to run in the same Deployment. Supports `name`, `image`, `args`, `env`, `envFrom`, `ports`, `livenessProbe`, `readinessProbe`, and `volumeMounts`. | `[]` |
@@ -220,6 +221,9 @@ apps:
       enabled: true
       className: nginx
       certManagerClusterIssuer: letsencrypt-prod
+      middlewares:
+        stripPrefix:
+          - /qt
       hosts:
         - host: whoami.local
           paths:

--- a/app-chart/templates/ingress.yaml
+++ b/app-chart/templates/ingress.yaml
@@ -17,10 +17,19 @@ kind: Ingress
 metadata:
   name: {{ $ingressName }}
   namespace: {{ $.Release.Namespace }}
-{{- if or ($ing.annotations) ($ing.certManagerClusterIssuer) }}
+{{- $middlewares := list -}}
+{{- if $ing.middlewares -}}
+  {{- if $ing.middlewares.stripPrefix -}}
+    {{- $middlewares = append $middlewares (printf "%s-%s-strip-prefix@kubernetescrd" $.Release.Namespace $appName) -}}
+  {{- end -}}
+{{- end -}}
+{{- if or ($ing.annotations) ($ing.certManagerClusterIssuer) (gt (len $middlewares) 0) }}
   annotations:
 {{- if $ing.certManagerClusterIssuer }}
     cert-manager.io/cluster-issuer: {{ $ing.certManagerClusterIssuer | quote }}
+{{- end }}
+{{- if gt (len $middlewares) 0 }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ join "," $middlewares | quote }}
 {{- end }}
 {{- range $key, $value := $ing.annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/app-chart/templates/middleware.yaml
+++ b/app-chart/templates/middleware.yaml
@@ -1,0 +1,24 @@
+{{- $root := . }}
+{{- range $appName, $app := .Values.apps }}
+{{- $ing := $app.ingress }}
+{{- if and (or (not (hasKey $app "enabled")) $app.enabled) ($ing.enabled | default false) ($ing.middlewares) }}
+{{- if $ing.middlewares.stripPrefix }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $appName }}-strip-prefix
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ $appName }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+spec:
+  stripPrefix:
+    prefixes:
+{{- range $prefix := $ing.middlewares.stripPrefix }}
+      - {{ $prefix | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/app-chart/values.schema.json
+++ b/app-chart/values.schema.json
@@ -432,6 +432,16 @@
               "type": "object",
               "additionalProperties": { "type": "string" }
             },
+            "middlewares": {
+              "type": "object",
+              "properties": {
+                "stripPrefix": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              },
+              "additionalProperties": false
+            },
             "hosts": {
               "type": "array",
               "items": { "$ref": "#/definitions/ingressHost" }

--- a/app-chart/values.yaml
+++ b/app-chart/values.yaml
@@ -62,6 +62,9 @@ apps:
   #       className: nginx
   #       certManagerClusterIssuer: "letsencrypt-prod"
   #       annotations: {}
+  #       middlewares:
+  #         stripPrefix:
+  #           - /qt
   #       hosts:
   #         - host: whoami.local
   #           paths:


### PR DESCRIPTION
Introduce `ingress.middlewares.stripPrefix` to `app-chart` to automatically generate Traefik Middleware resources and wire them to Ingress annotations. This follows the intent-driven design philosophy by abstracting technical implementation details from the service owner.

- Add `middleware.yaml` template for Traefik CRD generation
- Update `ingress.yaml` to auto-wire middlewares via annotations
- Document design philosophy in `AGENTS.md` and usage in `README.md`
- Enhance `Taskfile.yml` with `diff-values` for manifest regression testing
- Update `values.schema.json` with new middleware definitions