### PR TITLE
feat: interface out network policies for intent-driven config

### DIFF
--- a/app-chart/templates/network-policy.yaml
+++ b/app-chart/templates/network-policy.yaml
@@ -1,14 +1,31 @@
+{{- if .Values.networkPolicy.enabled -}}
+
+{{- if .Values.networkPolicy.defaults.isolateNamespace }}
 ---
-# 1. THE FOUNDATION: Allow DNS and Kube-System Access
+# 1. THE FOUNDATION: Default Isolation (Deny All)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: base-isolation
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   podSelector: {}
   policyTypes:
     - Ingress
+    - Egress
+{{- end }}
+
+{{- if .Values.networkPolicy.defaults.allowDNS }}
+---
+# 2. DNS ACCESS: Allow DNS resolution
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  podSelector: {}
+  policyTypes:
     - Egress
   egress:
     - to:
@@ -20,14 +37,55 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- end }}
 
+{{- if .Values.networkPolicy.defaults.allowSameNamespace }}
 ---
-# 2. THE EXIT: Allow Internet (Public IPs only)
+# 3. THE NEIGHBORS: Allow All Traffic Within the Namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+{{- end }}
+
+{{- if .Values.networkPolicy.defaults.ingressController.enabled }}
+---
+# 4. THE ENTRANCE: Allow Ingress Controller Traffic
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-controller
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            {{- toYaml .Values.networkPolicy.defaults.ingressController.namespaceSelector | nindent 14 }}
+{{- end }}
+
+{{- if .Values.networkPolicy.defaults.allowInternetEgress }}
+---
+# 5. GLOBAL INTERNET: Allow Public Internet Egress
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: allow-internet-egress
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   podSelector: {}
   policyTypes:
@@ -40,39 +98,73 @@ spec:
               - 10.0.0.0/8
               - 172.16.0.0/12
               - 192.168.0.0/16
+{{- end }}
 
+{{- if or .Values.networkPolicy.globalRules.ingress .Values.networkPolicy.globalRules.egress }}
 ---
-# 3. THE ENTRANCE: Allow Traefik Ingress
+# 6. GLOBAL RULES: Custom namespace-wide rules
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-ingress-traffic
-  namespace: "{{ .Release.Namespace }}"
+  name: global-custom-rules
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   podSelector: {}
   policyTypes:
+    {{- if .Values.networkPolicy.globalRules.ingress }}
     - Ingress
+    {{- end }}
+    {{- if .Values.networkPolicy.globalRules.egress }}
+    - Egress
+    {{- end }}
+  {{- if .Values.networkPolicy.globalRules.ingress }}
   ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: traefik
+    {{- toYaml .Values.networkPolicy.globalRules.ingress | nindent 4 }}
+  {{- end }}
+  {{- if .Values.networkPolicy.globalRules.egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.globalRules.egress | nindent 4 }}
+  {{- end }}
+{{- end }}
 
+{{- range $appName, $app := .Values.apps }}
+{{- if $app.networkPolicy }}
 ---
-# 4. THE NEIGHBORS: Allow All Traffic Within the Namespace
+# APP POLICY: {{ $appName }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-same-namespace
-  namespace: "{{ .Release.Namespace }}"
+  name: {{ printf "app-%s" $appName | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
 spec:
-  podSelector: {} # Target all pods in this namespace
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $appName | quote }}
   policyTypes:
-    - Ingress
+    {{- if or $app.networkPolicy.allowInternetEgress $app.networkPolicy.egress }}
     - Egress
+    {{- end }}
+    {{- if $app.networkPolicy.ingress }}
+    - Ingress
+    {{- end }}
+  {{- if $app.networkPolicy.ingress }}
   ingress:
-    - from:
-        - podSelector: {} # Allow from all pods in this namespace
+    {{- toYaml $app.networkPolicy.ingress | nindent 4 }}
+  {{- end }}
   egress:
+    {{- if $app.networkPolicy.allowInternetEgress }}
     - to:
-        - podSelector: {} # Allow to all pods in this namespace
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+    {{- end }}
+    {{- if $app.networkPolicy.egress }}
+    {{- toYaml $app.networkPolicy.egress | nindent 4 }}
+    {{- end }}
+{{- end }}
+{{- end }}
+
+{{- end }}

--- a/app-chart/values.schema.json
+++ b/app-chart/values.schema.json
@@ -74,6 +74,43 @@
       },
       "additionalProperties": false
     },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable or disable NetworkPolicies.",
+          "default": true
+        },
+        "defaults": {
+          "type": "object",
+          "properties": {
+            "isolateNamespace": { "type": "boolean", "default": true },
+            "allowDNS": { "type": "boolean", "default": true },
+            "allowSameNamespace": { "type": "boolean", "default": true },
+            "allowInternetEgress": { "type": "boolean", "default": true },
+            "ingressController": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean", "default": true },
+                "namespaceSelector": { "type": "object" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "globalRules": {
+          "type": "object",
+          "properties": {
+            "ingress": { "type": "array", "items": { "type": "object" } },
+            "egress": { "type": "array", "items": { "type": "object" } }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "configMaps": {
       "type": "object",
       "default": {},
@@ -411,6 +448,15 @@
           "type": "array",
           "items": { "$ref": "#/definitions/volumeSpec" },
           "default": []
+        },
+        "networkPolicy": {
+          "type": "object",
+          "properties": {
+            "allowInternetEgress": { "type": "boolean", "default": false },
+            "ingress": { "type": "array", "items": { "type": "object" } },
+            "egress": { "type": "array", "items": { "type": "object" } }
+          },
+          "additionalProperties": false
         },
         "initContainers": {
           "type": "array",

--- a/app-chart/values.yaml
+++ b/app-chart/values.yaml
@@ -39,6 +39,33 @@ clusterName: ""
 namespace:
   enabled: false
 
+# -- Global configuration for Network Policies across the entire namespace.
+networkPolicy:
+  # -- Enable or disable the creation of NetworkPolicies.
+  enabled: true
+
+  # Base policies applied to the entire namespace (podSelector: {})
+  defaults:
+    # -- Enable default deny-all (Ingress/Egress) for the namespace.
+    isolateNamespace: true
+    # -- Allow DNS (UDP/TCP 53) to the kube-system namespace.
+    allowDNS: true
+    # -- Allow all traffic between pods within this namespace.
+    allowSameNamespace: true
+    # -- Allow external internet egress (blocks RFC1918 private IPs).
+    allowInternetEgress: true
+    # -- Allow ingress traffic from a specific ingress controller.
+    ingressController:
+      enabled: true
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik
+
+  # -- Additional global ingress rules applied to the entire namespace.
+  globalRules:
+    ingress: []
+    egress: []
+
 # -- Map of ConfigMaps shared across apps. Each entry renders a ConfigMap manifest that apps may mount via `configMounts`.
 configMaps:
   {}
@@ -97,6 +124,10 @@ apps:
   #       - name: shared-config
   #         path: /etc/app-config/config.yaml
   #         subPath: nested/config.yaml
+  #     networkPolicy:
+  #       allowInternetEgress: false
+  #       ingress: []
+  #       egress: []
   #     livenessProbe:
   #       enabled: true
   #       type: http


### PR DESCRIPTION
Refactor hardcoded NetworkPolicies into a modular, intent-driven system configurable via values.yaml. This allows service owners to express security requirements through high-level toggles while maintaining default isolation.

- Enable global namespace isolation and modular defaults (DNS, SameNamespace, IngressController).
- Support global and per-app internet egress toggles with RFC1918 blocklists.
- Provide 'escape hatch' for raw ingress/egress rules at global and app levels.
- Update JSON schema with comprehensive validation for new networkPolicy blocks.
- Maintain backward compatibility by enabling current policies by default.