### PR TITLE
feat: add default resource requests and limits

### DIFF
--- a/app-chart/templates/cronjob.yaml
+++ b/app-chart/templates/cronjob.yaml
@@ -102,7 +102,11 @@ spec:
               securityContext:
 {{ toYaml . | nindent 16 }}
 {{- end }}
-{{- with $container.resources }}
+{{- $cronResources := $container.resources }}
+{{- if not $cronResources }}
+  {{- $cronResources = $.Values.defaults.resources }}
+{{- end }}
+{{- with $cronResources }}
               resources:
 {{ toYaml . | nindent 16 }}
 {{- end }}

--- a/app-chart/templates/helpers/_deployment.tpl
+++ b/app-chart/templates/helpers/_deployment.tpl
@@ -30,7 +30,7 @@
   {{- with (include "app-chart.deployment.containerPorts" (dict "ports" $container.ports "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
   {{- with (include "app-chart.deployment.envFrom" (dict "envFrom" $container.envFrom)) }}{{ . | nindent 2 }}{{- end }}
   {{- with (include "app-chart.deployment.env" (dict "env" $container.env "context" $context "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
-  {{- with (include "app-chart.deployment.resources" (dict "resources" $container.resources)) }}{{ . | nindent 2 }}{{- end }}
+  {{- with (include "app-chart.deployment.resources" (dict "resources" $container.resources "context" $context)) }}{{ . | nindent 2 }}{{- end }}
   {{- with (include "app-chart.deployment.startupProbe" (dict "startupProbe" $container.startupProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
   {{- with (include "app-chart.deployment.livenessProbe" (dict "livenessProbe" $container.livenessProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
   {{- with (include "app-chart.deployment.readinessProbe" (dict "readinessProbe" $container.readinessProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
@@ -39,11 +39,15 @@
   {{- with (include "app-chart.deployment.volumeMounts" (dict "volumes" $mounts "configMounts" $container.configMounts "configMaps" $context.Values.configMaps "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
 {{- end }}
 
-{{/* Renders container resources */}}
+{{/* Renders container resources, falling back to defaults.resources */}}
 {{- define "app-chart.deployment.resources" -}}
-{{- if .resources -}}
+{{- $resources := .resources -}}
+{{- if and (not $resources) .context -}}
+  {{- $resources = .context.Values.defaults.resources -}}
+{{- end -}}
+{{- if $resources -}}
 resources:
-{{- toYaml .resources | nindent 2 -}}
+{{- toYaml $resources | nindent 2 -}}
 {{- end -}}
 {{- end }}
 

--- a/app-chart/values.schema.json
+++ b/app-chart/values.schema.json
@@ -59,6 +59,15 @@
             }
           },
           "additionalProperties": false
+        },
+        "resources": {
+          "type": "object",
+          "description": "Default resource requests and limits for all containers. Override per-app via apps.<name>.resources.",
+          "properties": {
+            "requests": { "type": "object" },
+            "limits": { "type": "object" }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": true

--- a/app-chart/values.yaml
+++ b/app-chart/values.yaml
@@ -32,6 +32,16 @@ defaults:
       keepMonthly: 24
       keepYearly: 3
 
+  # -- Default resource requests and limits for all containers (Deployments and CronJobs).
+  # Override per-app with `apps.<name>.resources` or per-CronJob with `cronJobs.<name>.container.resources`.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 # -- Optional cluster identifier used when building paths for shared backup secrets.
 clusterName: ""
 


### PR DESCRIPTION
## Summary
Adds `defaults.resources` with sensible baseline values. The deployment container helper and CronJob template fall back to these defaults when no per-container resources are specified.

## Kubescape Controls Fixed
- Ensure CPU limits are set (C-0270)
- Ensure memory limits are set (C-0271)
- Ensure CPU requests are set (C-0268)
- Ensure memory requests are set (C-0269)

## Defaults Applied
```yaml
defaults:
  resources:
    requests:
      cpu: 50m
      memory: 128Mi
    limits:
      cpu: 500m
      memory: 512Mi
```

## Override
- `apps.<name>.resources` replaces the default for that app
- `cronJobs.<name>.container.resources` replaces the default for that CronJob

## Testing
- `helm lint .` ✅
- `helm template` verified defaults render on whoami (no explicit resources) ✅
- `helm template` verified donetick (explicit resources) still uses its own values ✅