### PR TITLE
feat: auto-generate ingress TLS from hosts when certManagerClusterIssuer is set

### DIFF
--- a/app-chart/templates/ingress.yaml
+++ b/app-chart/templates/ingress.yaml
@@ -39,9 +39,18 @@ spec:
 {{- if $ing.className }}
   ingressClassName: {{ $ing.className }}
 {{- end }}
-{{- if $ing.tls }}
+{{- /* Auto-generate TLS from hosts when certManagerClusterIssuer is set but no explicit tls block */ -}}
+{{- $tlsEntries := $ing.tls -}}
+{{- if and (not $tlsEntries) $ing.certManagerClusterIssuer $ing.hosts -}}
+  {{- $autoHosts := list -}}
+  {{- range $host := $ing.hosts -}}
+    {{- $autoHosts = append $autoHosts $host.host -}}
+  {{- end -}}
+  {{- $tlsEntries = list (dict "hosts" $autoHosts) -}}
+{{- end -}}
+{{- if $tlsEntries }}
   tls:
-{{- range $tls := $ing.tls }}
+{{- range $tls := $tlsEntries }}
     - secretName: {{ $ingressName }}-tls
 {{- if $tls.hosts }}
       hosts:


### PR DESCRIPTION
## Summary
When an Ingress has `certManagerClusterIssuer` configured but no explicit `tls` block, the template now auto-generates TLS entries by collecting all host names from the `hosts` list. Eliminates host duplication and ensures all Ingresses are TLS-encrypted by default.

Explicit `tls` blocks still take priority when provided.

## Kubescape Controls Fixed
- Data in motion encryption – Ingress is TLS encrypted (C-0263)

## Before / After
**Before:** Users had to duplicate host names in both `hosts:` and `tls:` blocks.
**After:** Just set `certManagerClusterIssuer` — TLS is auto-derived from hosts.

## Testing
- `helm lint .` ✅
- `helm template` with whoami (has certManagerClusterIssuer, no explicit tls) — TLS block auto-generated ✅