### PR TITLE
feat: add Kubernetes recommended labels to all resources

### DIFF
--- a/app-chart/templates/deployment.yaml
+++ b/app-chart/templates/deployment.yaml
@@ -6,6 +6,8 @@ kind: Deployment
 metadata:
   name: {{ $appName }}
   namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "app-chart.labels" (dict "appName" $appName "context" $) | nindent 4 }}
 spec:
   {{- if $app.deployStrategy }}
   strategy:

--- a/app-chart/templates/helpers/_labels.tpl
+++ b/app-chart/templates/helpers/_labels.tpl
@@ -1,5 +1,6 @@
 {{/*
-Standard labels
+Standard labels – applied to all resources rendered by the chart.
+Includes the Kubernetes recommended labels and the legacy "app" selector.
 */}}
 {{- define "app-chart.labels" -}}
 app.kubernetes.io/name: {{ .appName }}
@@ -7,6 +8,9 @@ app.kubernetes.io/instance: {{ .context.Release.Name }}
 {{- if .context.Chart.AppVersion }}
 app.kubernetes.io/version: {{ .context.Chart.AppVersion | quote }}
 {{- end }}
+app.kubernetes.io/component: {{ .component | default "app" }}
+app.kubernetes.io/part-of: {{ .context.Release.Name }}
 app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .context.Chart.Name .context.Chart.Version | replace "+" "_" }}
 app: {{ .appName }}
 {{- end -}}


### PR DESCRIPTION
## Summary
Enhances the labels helper with `app.kubernetes.io/component`, `app.kubernetes.io/part-of`, and `helm.sh/chart`. Adds labels to Deployment metadata (previously only on pod templates).

## Kubescape Controls Fixed
- K8s common labels usage (C-0077)
- Label usage for resources (C-0076)

## New Labels Added
- `app.kubernetes.io/component` — defaults to `app`, accepts optional `component` parameter
- `app.kubernetes.io/part-of` — set to release name
- `helm.sh/chart` — chart name and version

## Testing
- `helm lint .` ✅
- `helm template` verified labels on Deployment metadata ✅