### PR TITLE
feat: auto-inject TCP liveness and readiness probes

### DIFF
--- a/app-chart/templates/helpers/_deployment.tpl
+++ b/app-chart/templates/helpers/_deployment.tpl
@@ -32,8 +32,22 @@
   {{- with (include "app-chart.deployment.env" (dict "env" $container.env "context" $context "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
   {{- with (include "app-chart.deployment.resources" (dict "resources" $container.resources)) }}{{ . | nindent 2 }}{{- end }}
   {{- with (include "app-chart.deployment.startupProbe" (dict "startupProbe" $container.startupProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
-  {{- with (include "app-chart.deployment.livenessProbe" (dict "livenessProbe" $container.livenessProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
-  {{- with (include "app-chart.deployment.readinessProbe" (dict "readinessProbe" $container.readinessProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
+  {{- /* Auto-generate TCP probes when ports exist but no probe is configured */ -}}
+  {{- $autoProbePort := "" -}}
+  {{- if $container.ports -}}
+    {{- $firstPort := index $container.ports 0 -}}
+    {{- $autoProbePort = default (printf "%s-%d" $appName (default 80 $firstPort.containerPort)) $firstPort.name -}}
+  {{- end -}}
+  {{- $livenessProbe := $container.livenessProbe -}}
+  {{- if and (not $livenessProbe) $autoProbePort -}}
+    {{- $livenessProbe = dict "type" "tcp" "port" $autoProbePort "initialDelaySeconds" 15 "periodSeconds" 20 "failureThreshold" 3 -}}
+  {{- end -}}
+  {{- with (include "app-chart.deployment.livenessProbe" (dict "livenessProbe" $livenessProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
+  {{- $readinessProbe := $container.readinessProbe -}}
+  {{- if and (not $readinessProbe) $autoProbePort -}}
+    {{- $readinessProbe = dict "type" "tcp" "port" $autoProbePort "initialDelaySeconds" 5 "periodSeconds" 10 "failureThreshold" 3 -}}
+  {{- end -}}
+  {{- with (include "app-chart.deployment.readinessProbe" (dict "readinessProbe" $readinessProbe "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}
   {{- /* Unify volume mounts: main container uses .volumes, sidecars use .volumeMounts */ -}}
   {{- $mounts := $container.volumeMounts | default $container.volumes -}}
   {{- with (include "app-chart.deployment.volumeMounts" (dict "volumes" $mounts "configMounts" $container.configMounts "configMaps" $context.Values.configMaps "appName" $appName)) }}{{ . | nindent 2 }}{{- end }}


### PR DESCRIPTION
## Summary
Auto-generates TCP liveness and readiness probes for containers that have ports defined but no explicit probes.

## Kubescape Controls Fixed
- Configured liveness probe (C-0002)
- Configured readiness probe (C-0009)

## Defaults Applied
- **Liveness:** 15s delay, 20s period, 3 failures
- **Readiness:** 5s delay, 10s period, 3 failures

## Override
- Disable per-app with `livenessProbe.enabled: false` or `readinessProbe.enabled: false`.
- Explicit probes still take priority.

## Testing
- `helm lint .` ✅
- `helm template` verified probes auto-inject for whoami ✅