### PR TITLE
feat: add ServiceAccount support with automount disabled by default

### DIFF
--- a/app-chart/templates/deployment.yaml
+++ b/app-chart/templates/deployment.yaml
@@ -21,6 +21,11 @@ spec:
       labels:
         {{- include "app-chart.labels" (dict "appName" $appName "context" $) | nindent 8 }}
     spec:
+      {{- $sa := default (dict) $app.serviceAccount }}
+      {{- if $sa.create }}
+      serviceAccountName: {{ default $appName $sa.name }}
+      {{- end }}
+      automountServiceAccountToken: {{ $sa.automountServiceAccountToken | default false }}
       {{- if $app.initContainers }}
       initContainers:
 {{- range $init := $app.initContainers }}

--- a/app-chart/templates/serviceaccount.yaml
+++ b/app-chart/templates/serviceaccount.yaml
@@ -1,0 +1,22 @@
+{{- range $appName, $app := .Values.apps }}
+{{- if or (not (hasKey $app "enabled")) $app.enabled }}
+{{- $sa := default (dict) $app.serviceAccount }}
+{{- if $sa.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default $appName $sa.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "app-chart.labels" (dict "appName" $appName "context" $) | nindent 4 }}
+  {{- with $sa.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if hasKey $sa "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ $sa.automountServiceAccountToken }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/app-chart/values.schema.json
+++ b/app-chart/values.schema.json
@@ -458,6 +458,17 @@
           },
           "additionalProperties": false
         },
+        "serviceAccount": {
+          "type": "object",
+          "description": "ServiceAccount configuration for this app.",
+          "properties": {
+            "create": { "type": "boolean", "default": false, "description": "Create a dedicated ServiceAccount for this app." },
+            "name": { "type": "string", "description": "Override the ServiceAccount name (defaults to app name)." },
+            "automountServiceAccountToken": { "type": "boolean", "default": false, "description": "Mount the service account token into pods." },
+            "annotations": { "type": "object", "additionalProperties": { "type": "string" } }
+          },
+          "additionalProperties": false
+        },
         "initContainers": {
           "type": "array",
           "items": { "$ref": "#/definitions/sidecarSpec" },


### PR DESCRIPTION
## Summary
Adds `ServiceAccount` resource creation support per-app and defaults `automountServiceAccountToken: false` on all pods to reduce attack surface.

## Security Improvement
Reduces potential for credential theft if a pod is compromised by not mounting the default service account token unless explicitly required.

## Configuration
- `apps.<name>.serviceAccount.create`: true
- `apps.<name>.serviceAccount.automountServiceAccountToken`: true (if required)

## Testing
- `helm lint .` ✅
- `helm template` verified `automountServiceAccountToken: false` renders by default ✅