### PR TITLE
feat: always render imagePullPolicy with IfNotPresent default

### DIFF
--- a/app-chart/templates/helpers/_deployment.tpl
+++ b/app-chart/templates/helpers/_deployment.tpl
@@ -6,9 +6,7 @@
 {{- $name := .name -}}
 - name: {{ $name }}
   image: "{{ $container.image.repository }}:{{ $container.image.tag | default "latest" }}"
-  {{- with $container.image.pullPolicy }}
-  imagePullPolicy: {{ . }}
-  {{- end }}
+  imagePullPolicy: {{ $container.image.pullPolicy | default "IfNotPresent" }}
   {{- with $container.command }}
   command:
 {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## Summary
Ensures `imagePullPolicy` is always rendered, defaulting to `IfNotPresent`. Prevents silent drift from tags (like `latest`) that would otherwise default to `Always`.

## Testing
- `helm lint .` ✅
- `helm template` verified `imagePullPolicy: IfNotPresent` renders on all containers ✅