### PR TITLE
feat: add topologySpreadConstraints support for HA scheduling

### DIFF
--- a/app-chart/templates/deployment.yaml
+++ b/app-chart/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
       labels:
         {{- include "app-chart.labels" (dict "appName" $appName "context" $) | nindent 8 }}
     spec:
+      {{- with $app.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $app.initContainers }}
       initContainers:
 {{- range $init := $app.initContainers }}

--- a/app-chart/values.schema.json
+++ b/app-chart/values.schema.json
@@ -414,6 +414,12 @@
         "enabled": { "type": "boolean", "default": true },
         "replicas": { "type": "integer", "minimum": 1 },
         "deployStrategy": { "type": "string" },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "description": "Pod topology spread constraints for HA scheduling.",
+          "items": { "type": "object" },
+          "default": []
+        },
         "image": { "$ref": "#/definitions/image" },
         "args": {
           "type": "array",


### PR DESCRIPTION
## Summary
Adds support for `topologySpreadConstraints` in the Deployment pod spec to enable high-availability scheduling.

## Configuration
Example:
```yaml
topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: ScheduleAnyway
    labelSelector:
      matchLabels:
        app: myapp
```

## Testing
- `helm lint .` ✅