### PR TITLE
feat: add PodDisruptionBudget support

### DIFF
--- a/app-chart/templates/pdb.yaml
+++ b/app-chart/templates/pdb.yaml
@@ -1,0 +1,26 @@
+{{- range $appName, $app := .Values.apps }}
+{{- if or (not (hasKey $app "enabled")) $app.enabled }}
+{{- $pdb := default (dict) $app.pdb }}
+{{- if $pdb.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $appName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "app-chart.labels" (dict "appName" $appName "context" $) | nindent 4 }}
+spec:
+  {{- if $pdb.minAvailable }}
+  minAvailable: {{ $pdb.minAvailable }}
+  {{- else if $pdb.maxUnavailable }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ $appName }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/app-chart/values.schema.json
+++ b/app-chart/values.schema.json
@@ -521,6 +521,22 @@
             "maxAllowed": { "type": "object" }
           },
           "additionalProperties": false
+        },
+        "pdb": {
+          "type": "object",
+          "description": "PodDisruptionBudget configuration for this app.",
+          "properties": {
+            "enabled": { "type": "boolean", "default": false },
+            "minAvailable": {
+              "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "string" }],
+              "description": "Minimum available pods during voluntary disruptions."
+            },
+            "maxUnavailable": {
+              "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "string" }],
+              "description": "Maximum unavailable pods during voluntary disruptions."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "required": ["image"],


### PR DESCRIPTION
## Summary
Adds a new template for `PodDisruptionBudget` to protect apps during voluntary disruptions (e.g., node drains).

## Configuration
- `apps.<name>.pdb.enabled: true`
- Supports `minAvailable` and `maxUnavailable`.

## Testing
- `helm lint .` ✅