### PR TITLE
feat: add container lifecycle hooks support and enforce diff-values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ helm template . --values values.yaml
 
 `helm lint` should pass before every commit. Use `helm template` (with any ad-hoc `values-<name>.yaml`) to verify rendering for new combinations, and finish with the dry-run upgrade command against the namespace you plan to target. Do not commit value files that contain secrets or personal overrides.
 
+You should also run `task diff-values` from the root of the repository to ensure no unintended changes were introduced, verifying backwards compatibility. If the command highlights any differences, ensure they are intentional and call them out as good defaults or intended changes.
+
 ## Values Design & Coding Style
 
 - `app-chart/values.yaml` must read from a service-owner perspective: describe intent (apps, ingress needs, desired ports) and let the templates translate to Kubernetes structures. YAML uses two-space indentation and lowercase hyphenated keys. Template files rely on Go template trimming (`{{- ... -}}`) to keep manifests tidy. Favor boolean `enabled` flags for toggles (`apps.<name>.enabled`, `apps.<name>.ingress.enabled`, `namespace.enabled`) and name two-dimensional structures by what they configure (e.g., `ports[].service.nodePort`). Metadata names must remain DNS-1123 compliant; templates currently derive them from the entry's app key.
@@ -42,7 +44,7 @@ helm template . --values values.yaml
 
 ## Testing & Review Expectations
 
-Treat `helm lint` and `helm template .` (run from inside the target chart directory) as the minimum test. Augment with `helm template` runs that cover ingress enabled and disabled paths, multiple port definitions, and namespace creation. Before requesting review, capture the exact commands you ran along with any rendered manifest snippets that illustrate behavioral changes (new ports, hosts, TLS blocks, etc.).
+Treat `helm lint`, `helm template .` (run from inside the target chart directory), and `task diff-values` (run from the repository root) as the minimum test. Augment with `helm template` runs that cover ingress enabled and disabled paths, multiple port definitions, and namespace creation. The `task diff-values` command is critical to guarantee backwards compatibility and catch any unintended regressions across all environments. Before requesting review, capture the exact commands you ran along with any rendered manifest snippets that illustrate behavioral changes (new ports, hosts, TLS blocks, etc.). If `task diff-values` yields any output, it must be noted as an intentional change.
 
 ## Commit & Pull Request Guidelines
 

--- a/app-chart/README.md
+++ b/app-chart/README.md
@@ -67,7 +67,8 @@ The workflow uses `${{ secrets.GITHUB_TOKEN }}` with `packages: write` permissio
 | `ingress.middlewares` | object | Intent-driven Traefik middleware configuration. Supports `stripPrefix`. Automatically generates CRDs and wires Ingress annotations. | `{}` |
 | `livenessProbe`    | object | Optional container liveness probe. Supports `type: command` (exec) or `type: http` (HTTP GET) alongside standard timing fields. | disabled                                               |
 | `readinessProbe`   | object | Optional readiness probe using the same schema (`type: command` or `type: http`).                                           | disabled                                               |
-| `sidecars`         | array  | Optional list of sidecar containers to run in the same Deployment. Supports `name`, `image`, `args`, `env`, `envFrom`, `ports`, `livenessProbe`, `readinessProbe`, and `volumeMounts`. | `[]` |
+| `lifecycle`        | object | Optional container lifecycle hooks such as `postStart` and `preStop`.                                                       | disabled                                               |
+| `sidecars`         | array  | Optional list of sidecar containers to run in the same Deployment. Supports `name`, `image`, `args`, `env`, `envFrom`, `ports`, `livenessProbe`, `readinessProbe`, `lifecycle`, and `volumeMounts`. | `[]` |
 
 ### `configMaps.<name>` object
 
@@ -152,6 +153,7 @@ Each entry renders a Kubernetes `CronJob` with a single container definition. Va
 | `container.env`                        | array  | Same templated env structure as Deployments (supports `tpl` and `valueFrom`).                                   | `[]`           |
 | `container.resources`                  | object | Resource requests/limits map.                                                                                   | `{}`           |
 | `container.securityContext`            | object | Container-level security context.                                                                               | `{}`           |
+| `container.lifecycle`                  | object | Optional container lifecycle hooks such as `postStart` and `preStop`.                                           | unset          |
 | `volumes[]`                            | array  | Optional shared volume definitions reused for mounts and pod volumes (same structure as `apps.<name>.volumes`). | `[]`           |
 
 Example:

--- a/app-chart/templates/helpers/_deployment.tpl
+++ b/app-chart/templates/helpers/_deployment.tpl
@@ -20,6 +20,10 @@
   {{- with $container.workingDir }}
   workingDir: {{ . }}
   {{- end }}
+  {{- with $container.lifecycle }}
+  lifecycle:
+{{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- $containerSC := $container.securityContext }}
   {{- if not $containerSC }}
     {{- $containerSC = $context.Values.defaults.containerSecurityContext }}

--- a/app-chart/values.schema.json
+++ b/app-chart/values.schema.json
@@ -221,6 +221,7 @@
         },
         "resources": { "type": "object" },
         "securityContext": { "type": "object" },
+        "lifecycle": { "type": "object" },
         "restartPolicy": {
           "type": "string",
           "enum": ["Always", "OnFailure", "Never"],
@@ -453,6 +454,7 @@
         "startupProbe": { "$ref": "#/definitions/probe" },
         "livenessProbe": { "$ref": "#/definitions/probe" },
         "readinessProbe": { "$ref": "#/definitions/probe" },
+        "lifecycle": { "type": "object" },
         "service": { "$ref": "#/definitions/servicePort" },
         "ports": {
           "type": "array",
@@ -621,7 +623,8 @@
           "default": []
         },
         "resources": { "type": "object" },
-        "securityContext": { "type": "object" }
+        "securityContext": { "type": "object" },
+        "lifecycle": { "type": "object" }
       },
       "required": ["image"],
       "additionalProperties": true

--- a/app-chart/values.yaml
+++ b/app-chart/values.yaml
@@ -177,6 +177,10 @@ apps:
   #       periodSeconds: 10
   #       timeoutSeconds: 1
   #       successThreshold: 1
+  #     lifecycle:
+  #       postStart:
+  #         exec:
+  #           command: ["/bin/sh", "-c", "echo Hello"]
   #     service:
   #       type: ClusterIP
   #     ports:


### PR DESCRIPTION
This commit introduces support for Kubernetes `lifecycle` hooks (such as `postStart` and `preStop`) within container specifications.

Changes include:
- `_deployment.tpl`: Updated the `app-chart.deployment.container` helper to render the `lifecycle` block if provided.
- `values.schema.json`: Added the `lifecycle` object definition to `appSpec`, `sidecarSpec`, and `cronJobContainer` for validation.
- `values.yaml` & `README.md`: Included examples and documentation for utilizing the new `lifecycle` hooks.
- `AGENTS.md`: Updated AI guidelines to require running `task diff-values` to guarantee backwards compatibility on future changes.